### PR TITLE
Update CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           key: v6-dependencies-{{ checksum "package.json" }}
       - run:
           name: Run e2e tests against server set in API_BASE_URL env var.
-          command: API_BASE_URL=https://tpp-reference-server.herokuapp.com/open-banking/v1.1 REDIRECT_DELAY_SECONDS=1 npm run e2e
+          command: API_BASE_URL=https://tpp-reference-server-mock.herokuapp.com/open-banking/v1.1 REDIRECT_DELAY_SECONDS=1 npm run e2e
       - run:
           name: Run unit tests
           command: npm run unit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tpp-reference-client",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
- Configure CI e2e tests to point to new API server URI for mock environment
- Bump package-lock to v0.3.0

For: #REFAPP-80