### PR TITLE
Fix accountRequestConsentUri to use host from API_BASE_URL - REFAPP-102

### DIFF
--- a/config/prod.env.js
+++ b/config/prod.env.js
@@ -9,6 +9,5 @@ const stringify = (val) => {
 module.exports = {
   NODE_ENV: '"production"',
   API_BASE_URL: stringify(process.env.API_BASE_URL),
-  ACCOUNT_REQUEST_CONSENT_URI: stringify(process.env.ACCOUNT_REQUEST_CONSENT_URI),
   REDIRECT_DELAY_SECONDS: process.env.REDIRECT_DELAY_SECONDS,
 };

--- a/src/store/request.js
+++ b/src/store/request.js
@@ -2,7 +2,7 @@
 import 'whatwg-fetch';
 
 export const baseUri = (process.env.API_BASE_URL || 'http://localhost:8003/open-banking/v1.1');
-export const accountRequestConsentUri = (process.env.ACCOUNT_REQUEST_CONSENT_URI || 'http://localhost:8003/account-request-authorise-consent');
+export const accountRequestConsentUri = baseUri.replace('/open-banking/v1.1', '/account-request-authorise-consent');
 export const rootUri = `${baseUri.split('/open-banking')[0]}`;
 
 const makeHeaders = (aspsp) => {


### PR DESCRIPTION
Fix `accountRequestConsentUri` to contain correct host when deployed to heroku.