### PR TITLE
Redirect to /auth URI from account request response

### DIFF
--- a/src/store/request.js
+++ b/src/store/request.js
@@ -30,6 +30,12 @@ const makeHeaders = (aspsp) => {
 };
 
 const asyncAwaitPostJson = async (endpoint, aspsp, data, unauthorizedType) => {
+  const decodeUri = uri => uri; // Get the params etc
+  const redirectHandler = (uri) => {
+    // Implementation TBD - store Redirect URI etc
+    const url = decodeUri(uri);
+    window.location = url;
+  };
   const { headers } = makeHeaders(aspsp);
   headers['Content-Type'] = 'application/json';
   const response = await fetch(endpoint, {
@@ -37,6 +43,11 @@ const asyncAwaitPostJson = async (endpoint, aspsp, data, unauthorizedType) => {
     headers,
     body: JSON.stringify(data),
   });
+  // We can't intercept a 302 :-(
+  if (response.status === 200) {
+    response.json()
+      .then(body => redirectHandler(body.uri));
+  }
   if (response.status === 204) {
     return null;
   } else if (response.status === 401) {


### PR DESCRIPTION
Take /auth URI from response payload, and set window location to that URI.

To keep tests working, have not disabled the forced change to accounts view after `REDIRECT_DELAY_SECONDS` delay.

To be merged with: https://github.com/OpenBankingUK/tpp-reference-server/pull/59