### PR TITLE
REFAPP-127 Track Selected Activity to enable component reuse on TPP Client.

### DIFF
--- a/src/components/ActivitySelection.vue
+++ b/src/components/ActivitySelection.vue
@@ -29,9 +29,11 @@ export default {
   computed: { },
   methods: {
     viewBalances() {
+      this.$store.dispatch('selectActivity', 'view-balances');
       this.$router.push('aspsp-selection');
     },
     makePayment() {
+      this.$store.dispatch('selectActivity', 'make-payment');
       this.$router.push('/activity-selection');
     },
   },

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
+import activitySelection from './modules/activity-selection';
 import accounts from './modules/accounts';
 import aspspAuthorisationServers from './modules/aspsp-authorisation-servers';
 import session from './modules/session';
@@ -9,6 +10,7 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   modules: {
+    activitySelection,
     accounts,
     aspspAuthorisationServers,
     session,

--- a/src/store/modules/activity-selection.js
+++ b/src/store/modules/activity-selection.js
@@ -1,0 +1,31 @@
+import Vue from 'vue';
+import { SELECT_ACTIVITY } from '../mutation-types';
+
+const initialState = {
+  selectedActivity: null,
+};
+
+const getters = {
+  selectedActivity: state => () => { // eslint-disable-line
+    return state.selectedActivity;
+  },
+};
+
+const mutations = {
+  [SELECT_ACTIVITY](state, activity) {
+    Vue.set(state, 'selectedActivity', activity);
+  },
+};
+
+const actions = {
+  selectActivity({ commit }, activity) {
+    return commit(SELECT_ACTIVITY, activity);
+  },
+};
+
+export default {
+  state: initialState,
+  getters,
+  mutations,
+  actions,
+};

--- a/src/store/mutation-types.js
+++ b/src/store/mutation-types.js
@@ -1,3 +1,4 @@
+export const SELECT_ACTIVITY = 'SELECT_ACTIVITY';
 export const ASPSPS_FETCH = 'ASPSPS_FETCH';
 export const ASPSPS_SUCCESS = 'ASPSPS_SUCCESS';
 export const SELECT_ASPSP = 'SELECT_ASPSP';


### PR DESCRIPTION
Added an `activity-selection` module to store and track `selectedActivity` across views.