### PR TITLE
Disable ASPSP logo display - REFAPP 172

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   },
   "licence": "MIT",
   "engines": {
-    "node": "8.9.0",
+    "node": "~8.9.0",
     "npm": ">= 5.3.0"
   },
   "browserslist": [

--- a/src/components/AspspSelect.vue
+++ b/src/components/AspspSelect.vue
@@ -2,7 +2,7 @@
   <div class="aspsp-select item">
     <div class="ui hidden divider"></div>
     <div class="ui tiny image">
-      <img v-if="hasLogo" :src="logoUri">
+      <img v-if="hasLogo" :src="logoUri" height="40">
     </div>
     <div class="middle aligned content">
       <div class="header">
@@ -25,7 +25,10 @@ export default {
       return this.aspsp.logoUri;
     },
     hasLogo() {
-      return this.logoUri && this.logoUri !== '';
+      // return this.logoUri && this.logoUri !== '';
+      // todo: need to check logo URI valid on server before attempting to display
+      // for now return false
+      return false;
     },
   },
   methods: {

--- a/src/components/AspspSelect.vue
+++ b/src/components/AspspSelect.vue
@@ -2,7 +2,7 @@
   <div class="aspsp-select item">
     <div class="ui hidden divider"></div>
     <div class="ui tiny image">
-      <img src="">
+      <img v-if="hasLogo" :src="logoUri">
     </div>
     <div class="middle aligned content">
       <div class="header">
@@ -20,6 +20,12 @@ export default {
   computed: {
     name() {
       return this.aspsp.name;
+    },
+    logoUri() {
+      return this.aspsp.logoUri;
+    },
+    hasLogo() {
+      return this.logoUri && this.logoUri !== '';
     },
   },
   methods: {


### PR DESCRIPTION
- We need to check logo URI is valid on server before attempting to display.
- Reference bank is currently configured with image URIs that don't exist.
- For now disable ASPSP logo display.