### PR TITLE
Before test run ensure consent not granted

### DIFF
--- a/src/components/RevokeAccountsConsent.vue
+++ b/src/components/RevokeAccountsConsent.vue
@@ -5,6 +5,7 @@
       Revoke consent
     </button>
     <span v-if="!accountsAndConsentGranted"
+      id="consent-revoked"
       class="ui positive message">Consent revoked</span>
   </div>
 </template>

--- a/test/e2e/features/always-start-without-consent.feature
+++ b/test/e2e/features/always-start-without-consent.feature
@@ -5,4 +5,5 @@ Scenario: Revoke accounts consent if present
   Given I am logged in
   And I select View Balances
   When I select an ASPSP
+  And I wait some time
   Then revoke consent if present

--- a/test/e2e/features/always-start-without-consent.feature
+++ b/test/e2e/features/always-start-without-consent.feature
@@ -1,0 +1,8 @@
+Feature: Before test run ensure consent not granted
+
+Scenario: Revoke accounts consent if present
+
+  Given I am logged in
+  And I select View Balances
+  When I select an ASPSP
+  Then revoke consent if present

--- a/test/e2e/features/step_definitions/revoke-consent.js
+++ b/test/e2e/features/step_definitions/revoke-consent.js
@@ -3,6 +3,19 @@ const { defineSupportCode } = require('cucumber');
 
 defineSupportCode(({ Given, Then, When }) => { // eslint-disable-line
 
+  When('revoke consent if present', () => {
+    const revokeButton = 'button[name=revoke-consent]';
+    client.element('css selector', revokeButton, (result) => {
+      const revokeConsentButtonPresent = result.status !== -1;
+
+      if (revokeConsentButtonPresent) {
+        client
+          .click(revokeButton)
+          .click('button[name=logout]');
+      }
+    });
+  });
+
   When('I revoke consent', () => {
     client
       .waitForElementVisible('button[name=revoke-consent]', 5000)

--- a/test/e2e/features/step_definitions/revoke-consent.js
+++ b/test/e2e/features/step_definitions/revoke-consent.js
@@ -11,6 +11,7 @@ defineSupportCode(({ Given, Then, When }) => { // eslint-disable-line
       if (revokeConsentButtonPresent) {
         client
           .click(revokeButton)
+          .waitForElementVisible('#consent-revoked', 5000)
           .click('button[name=logout]');
       }
     });


### PR DESCRIPTION
- The e2e tests are run alphabetically by filename.
- In first test file, hence in first test, revoke accounts consent if present.